### PR TITLE
fix: couldn't update image from ECR

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ if (!AWS.config.region) {
   });
 }
 
-var updater = function(options, cb) {
+var updater = function (options, cb) {
   async.waterfall([
     (next) => updater.currentTaskDefinition(options, next),
     (currentTaskDefinition, next) => {
@@ -76,7 +76,7 @@ Object.assign(updater, {
 
     var params = {
       cluster: options.clusterArn,
-      services: [ options.serviceName ]
+      services: [options.serviceName]
     };
 
     ecs.describeServices(params, (err, data) => {
@@ -105,7 +105,7 @@ Object.assign(updater, {
       status: 'ACTIVE'
     };
 
-    ecs.listTaskDefinitions(params, function(err, data) {
+    ecs.listTaskDefinitions(params, function (err, data) {
       if (err) return cb(err);
       if (data.taskDefinitionArns.length === 0) {
         return cb(new Error(`No Task Definitions found in family "${family}"`));
@@ -140,21 +140,24 @@ Object.assign(updater, {
       var containerIndex = _.findIndex(newTaskDefinition.containerDefinitions, (containerDefinition) => {
         return containerDefinition.name === containerName;
       });
-      
+
       newTaskDefinition.containerDefinitions[containerIndex].image = image;
     });
 
-    return _.pick(newTaskDefinition, [
+    newTaskDefinition = _.pick(newTaskDefinition, [
       'containerDefinitions',
       'family',
       'networkMode',
       'placementConstraints',
       'taskRoleArn',
+      'executionRoleArn',
       'volumes',
       'requiresCompatibilities',
       'cpu',
       'memory'
     ]);
+
+    return newTaskDefinition
   },
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecs-service-image-updater",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
When pulling images from ecr, it shows the error `Fargate requires task definition to have execution role ARN to support log driver awslogs`.
It is because the script ignores `executionRoleArn` in task definition
json.

```
/Users/johnny/ph/ecs-service-image-updater/node_modules/aws-sdk/lib/request.js:31
            throw err;
            ^

ClientException: Fargate requires task definition to have execution role ARN to support log driver awslogs.
    at Request.extractError (/Users/johnny/ph/ecs-service-image-updater/node_modules/aws-sdk/lib/protocol/json.js:51:27)
    at Request.callListeners (/Users/johnny/ph/ecs-service-image-updater/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at Request.emit (/Users/johnny/ph/ecs-service-image-updater/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/Users/johnny/ph/ecs-service-image-updater/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/Users/johnny/ph/ecs-service-image-updater/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/johnny/ph/ecs-service-image-updater/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/johnny/ph/ecs-service-image-updater/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/johnny/ph/ecs-service-image-updater/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/johnny/ph/ecs-service-image-updater/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/Users/johnny/ph/ecs-service-image-updater/node_modules/aws-sdk/lib/sequential_executor.js:116:18)
```